### PR TITLE
Fix ZDD `operator~`

### DIFF
--- a/cplusplus/cuddObj.cc
+++ b/cplusplus/cuddObj.cc
@@ -1184,7 +1184,7 @@ ZDD::operator-=(
 ZDD
 ZDD::operator~() const
 {
-  DdNode *result = Cudd_zddComplement(p->manager, node);
+  DdNode *result = Cudd_zddDiff(p->manager, p->manager->univ[0], node);
   checkReturnValue(result);
   return ZDD(p, result);
 } // ZDD::operator~


### PR DESCRIPTION
Fixes https://github.com/SSoelvsten/bdd-benchmark/issues/139

The previously used `Cudd_zddComplement()` internally uses `Cudd_MakeBddFromZddCover()`, which—put the correctness issues aside—does not sound terribly (space) efficient either.

I tested this using a few small Picotrav/EPFL benchmark items.