### PR TITLE
Add Methods to Use ADDs as BDDs

### DIFF
--- a/cplusplus/cuddObj.cc
+++ b/cplusplus/cuddObj.cc
@@ -5714,6 +5714,15 @@ BDD::PickOneCube(
 
 } // BDD::PickOneCube
 
+void
+ADD::PickOneCube(
+  char * string) const
+{
+    DdManager *mgr = p->manager;
+    int result = Cudd_addPickOneCube(mgr, node, string);
+    checkReturnValue(result);
+} // ADD::PickOneCube
+
 
 BDD
 BDD::PickOneMinterm(
@@ -5731,6 +5740,15 @@ BDD::PickOneMinterm(
     return BDD(p, result);
 
 } // BDD::PickOneMinterm
+
+
+ADD
+ADD::PickOneMintermSet(const ADD& choice) const
+{
+    DdNode *result = Cudd_addPickOneMintermSet(p->manager, node, choice.node);
+    checkReturnValue(result);
+    return ADD(p, result);
+} // ADD::PickOneMintermSet
 
 
 BDD

--- a/cplusplus/cuddObj.cc
+++ b/cplusplus/cuddObj.cc
@@ -917,6 +917,33 @@ ADD::operator|=(
 } // ADD::operator|=
 
 
+ADD
+ADD::operator^(
+  const ADD& other) const
+{
+    DdManager *mgr = checkSameManager(other);
+    DdNode *result = Cudd_addApply(mgr,Cudd_addXor,node,other.node);
+    checkReturnValue(result);
+    return ADD(p, result);
+
+} // ADD::operator^
+
+
+ADD
+ADD::operator^=(
+  const ADD& other)
+{
+    DdManager *mgr = checkSameManager(other);
+    DdNode *result = Cudd_addApply(mgr,Cudd_addXor,node,other.node);
+    checkReturnValue(result);
+    Cudd_Ref(result);
+    Cudd_RecursiveDeref(mgr,node);
+    node = result;
+    return *this;
+
+} // ADD::operator^=
+
+
 bool
 ADD::IsZero() const
 {

--- a/cplusplus/cuddObj.hh
+++ b/cplusplus/cuddObj.hh
@@ -323,6 +323,8 @@ public:
     ADD operator&=(const ADD& other);
     ADD operator|(const ADD& other) const;
     ADD operator|=(const ADD& other);
+    ADD operator^(const ADD& other) const;
+    ADD operator^=(const ADD& other);
     bool IsZero() const;
     ADD ExistAbstract(const ADD& cube) const;
     ADD UnivAbstract(const ADD& cube) const;

--- a/cplusplus/cuddObj.hh
+++ b/cplusplus/cuddObj.hh
@@ -375,6 +375,8 @@ public:
     ADD Triangle(const ADD& g, std::vector<ADD> z) const;
     ADD Eval(int * inputs) const;
     bool EqualSupNorm(const ADD& g, CUDD_VALUE_TYPE tolerance, int pr) const;
+    void PickOneCube(char * string) const;
+    ADD PickOneMintermSet(const ADD& choice) const;
 
 }; // ADD
 

--- a/cudd/cudd.h
+++ b/cudd/cudd.h
@@ -696,6 +696,8 @@ extern DdNode * Cudd_addNegate(DdManager *dd, DdNode *f);
 extern DdNode * Cudd_addRoundOff(DdManager *dd, DdNode *f, int N);
 extern DdNode * Cudd_addWalsh(DdManager *dd, DdNode **x, DdNode **y, int n);
 extern DdNode * Cudd_addResidue(DdManager *dd, int n, int m, int options, int top);
+extern int Cudd_addPickOneCube(DdManager *ddm, DdNode *node, char *string);
+extern DdNode * Cudd_addPickOneMintermSet(DdManager *dd, DdNode *f, DdNode *choice);
 extern DdNode * Cudd_bddAndAbstract(DdManager *manager, DdNode *f, DdNode *g, DdNode *cube);
 extern DdNode * Cudd_bddAndAbstractLimit(DdManager *manager, DdNode *f, DdNode *g, DdNode *cube, unsigned int limit);
 extern int Cudd_ApaNumberOfDigits(int binaryDigits);


### PR DESCRIPTION
This adds a few methods to use CUDD's ADDs as BDDs in BDD Benchmark (https://github.com/SSoelvsten/bdd-benchmark/issues/111)

I did not yet test the new methods in detail—which are the relevant benchmarks in BDD Benchmark? Also I’m very open to renaming `PickOneMintermSet`. The “Set” part stems from BuDDy’s `satoneset`. For the rest, I tried to follow CUDD’s naming scheme. Using this method for BDD Benchmark’s `satone` seems to be way more elegant than `SupportIndices` and `PickOneMinterm`.

Closes #3