### PR TITLE
Prefix Cmake targets to avoid naming conflicts

### DIFF
--- a/cudd/CMakeLists.txt
+++ b/cudd/CMakeLists.txt
@@ -97,7 +97,7 @@ else()
   add_library(cudd STATIC ${CUDD_C_HEADERS} ${CUDD_CPP_HEADERS} ${CUDD_C_SOURCES} ${CUDD_CPP_SOURCES})
 endif()
 
-target_link_libraries(cudd PRIVATE epd mtr st util)
+target_link_libraries(cudd PRIVATE cudd_epd cudd_mtr cudd_st cudd_util)
 
 if (CUDD_STATS)
   target_compile_definitions(cudd PUBLIC DD_STATS)

--- a/dddmp/CMakeLists.txt
+++ b/dddmp/CMakeLists.txt
@@ -20,14 +20,14 @@ set(DDDMP_C_SOURCES
 )
 
 if (CUDD_SHARED)
-  add_library(dddmp SHARED ${DDDMP_C_HEADERS} ${DDDMP_C_SOURCES})
+  add_library(cudd_dddmp SHARED ${DDDMP_C_HEADERS} ${DDDMP_C_SOURCES})
 else()
-  add_library(dddmp STATIC ${DDDMP_C_HEADERS} ${DDDMP_C_SOURCES})
+  add_library(cudd_dddmp STATIC ${DDDMP_C_HEADERS} ${DDDMP_C_SOURCES})
 endif()
 
-target_link_libraries(dddmp PRIVATE util st mtr epd cudd)
+target_link_libraries(cudd_dddmp PRIVATE cudd_util cudd_st cudd_mtr cudd_epd cudd)
 
-target_include_directories(dddmp PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(cudd_dddmp PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                         ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties(cudd PROPERTIES

--- a/epd/CMakeLists.txt
+++ b/epd/CMakeLists.txt
@@ -7,9 +7,9 @@ set(EPD_C_SOURCES
   epd.c
 )
 
-add_library(epd STATIC ${EPD_C_HEADERS} ${EPD_C_SOURCES})
+add_library(cudd_epd STATIC ${EPD_C_HEADERS} ${EPD_C_SOURCES})
 
-target_link_libraries(epd PRIVATE util)
+target_link_libraries(cudd_epd PRIVATE cudd_util)
 
-target_include_directories(epd PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(cudd_epd PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                       ${CMAKE_CURRENT_SOURCE_DIR})

--- a/mtr/CMakeLists.txt
+++ b/mtr/CMakeLists.txt
@@ -9,9 +9,9 @@ set(MTR_C_SOURCES
   #testmtr.c
 )
 
-add_library(mtr STATIC ${MTR_C_HEADERS} ${MTR_C_SOURCES})
+add_library(cudd_mtr STATIC ${MTR_C_HEADERS} ${MTR_C_SOURCES})
 
-target_link_libraries(mtr PRIVATE util)
+target_link_libraries(cudd_mtr PRIVATE cudd_util)
 
-target_include_directories(mtr PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(cudd_mtr PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                       ${CMAKE_CURRENT_SOURCE_DIR})

--- a/nanotrav/CMakeLists.txt
+++ b/nanotrav/CMakeLists.txt
@@ -15,5 +15,5 @@ set(NANOTRAV_C_SOURCES
   main.c
 )
 
-add_executable(nanotrav ${NANOTRAV_C_HEADERS} ${NANOTRAV_C_SOURCES})
-target_link_libraries(nanotrav PRIVATE epd mtr st cudd util dddmp)
+add_executable(cudd_nanotrav ${NANOTRAV_C_HEADERS} ${NANOTRAV_C_SOURCES})
+target_link_libraries(cudd_nanotrav PRIVATE cudd_epd cudd_mtr cudd_st cudd cudd_util cudd_dddmp)

--- a/st/CMakeLists.txt
+++ b/st/CMakeLists.txt
@@ -7,9 +7,9 @@ set(ST_C_SOURCES
   #testst.c
 )
 
-add_library(st STATIC ${ST_C_HEADERS} ${ST_C_SOURCES})
+add_library(cudd_st STATIC ${ST_C_HEADERS} ${ST_C_SOURCES})
 
-target_link_libraries(st PRIVATE util)
+target_link_libraries(cudd_st PRIVATE cudd_util)
 
-target_include_directories(st PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(cudd_st PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                      ${CMAKE_CURRENT_SOURCE_DIR})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -20,7 +20,7 @@ set(UTIL_C_SOURCES
 # ============================================================================ #
 # Set up as (static) library
 
-add_library(util STATIC ${UTIL_C_HEADERS} ${UTIL_C_SOURCES})
+add_library(cudd_util STATIC ${UTIL_C_HEADERS} ${UTIL_C_SOURCES})
 
-target_include_directories(util PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+target_include_directories(cudd_util PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                        ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
As done on the fork by @Marcel-Schubert ; The problem that should be solved by this is that naming conflicts can occur, for instance, both cudd and z3 define a Cmake target util.